### PR TITLE
update GitHub Actions to use latest checkout and deploy-pages actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install, build, and upload your site
         uses: withastro/action@v1
         # with:
@@ -36,4 +36,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
This pull request updates the GitHub Actions configuration in `.github/workflows/deploy.yml` to use newer versions of the actions for checkout and deployment. 

Updates to GitHub Actions:

* Updated `actions/checkout` from version `v3` to `v4` to ensure compatibility with the latest features and improvements. (`[.github/workflows/deploy.ymlL22-R22](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L22-R22)`)
* Updated `actions/deploy-pages` from version `v1` to `v3` for enhanced functionality and stability during deployment. (`[.github/workflows/deploy.ymlL39-R39](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L39-R39)`)