### PR TITLE
update GitHub Actions to use latest versions of withastro/action and …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
       - name: Install, build, and upload your site
-        uses: withastro/action@v1
+        uses: withastro/action@v4
         # with:
         # path: . # The root location of your Astro project inside the repository. (optional)
         # node-version: 18 # The specific version of Node that should be used to build your site. Defaults to 18. (optional)
@@ -36,4 +36,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/deploy.yml` to use the latest versions of the actions for building and deploying the site.

Version updates in GitHub Actions:

* Updated the `withastro/action` action from version `v1` to `v4` to ensure compatibility with the latest features and improvements.
* Updated the `actions/deploy-pages` action from version `v3` to `v4` for deploying to GitHub Pages