### PR TITLE
fix: remove workflow_run trigger from deploy.yml and adjust Playwrigh…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,6 @@ on:
     branches: [main]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Playwright Tests"]
-    types:
-      - completed
 
 # Allow this job to clone the repo and create a page deployment
 permissions:
@@ -21,7 +17,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,5 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 jobs:


### PR DESCRIPTION
This pull request updates GitHub Actions workflows by simplifying the deployment process and modifying the Playwright testing workflow. The changes primarily involve removing unused triggers and conditions to streamline the workflows.

### Deployment workflow changes:
* Removed the `workflow_run` trigger that depended on the completion of the "Playwright Tests" workflow in `.github/workflows/deploy.yml`.
* Removed the conditional check for the success of the `workflow_run` event in the `build` job of `.github/workflows/deploy.yml`.

### Playwright testing workflow changes:
* Removed the `push` trigger for the "Playwright Tests" workflow in `.github/workflows/playwright.yml`, leaving only the `pull_request` trigger for the `main` branch.