### PR TITLE
Add group configuration for Astro updates in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      astro:
+        # Combine updates for Astro and official @astrojs/* integrations into one PR
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to group Astro-related dependencies into a single pull request. This change will help streamline dependency management for Astro and its official integrations.

Dependabot configuration improvements:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R12-R20): Added a `groups` section to combine updates for `astro` and all `@astrojs/*` packages into a single PR, and specified that only minor and patch updates should be grouped.